### PR TITLE
CMake macosx bundle .

### DIFF
--- a/proj/cmake/libcinder_configure_build.cmake
+++ b/proj/cmake/libcinder_configure_build.cmake
@@ -99,4 +99,7 @@ else()
 	set( CINDER_ANTTWEAKBAR_ENABLED TRUE )
 endif()
 
+set( ICON_NAME "CinderApp.icns" )
+set( ICON_PATH "${CINDER_ROOT}/samples/data/${ICON_NAME}" )
+
 message( "CINDER_ANTTWEAKBAR_ENABLED: ${CINDER_ANTTWEAKBAR_ENABLED}" )

--- a/proj/cmake/modules/cinderConfig.buildtree.cmake.in
+++ b/proj/cmake/modules/cinderConfig.buildtree.cmake.in
@@ -2,4 +2,7 @@ if( NOT TARGET cinder${CINDER_LIB_SUFFIX} )
     include( ${PROJECT_BINARY_DIR}/cinderTargets.cmake )
 endif()
 
+set( CINDER_ICON_NAME @ICON_NAME@ )
+set( CINDER_ICON_PATH @ICON_PATH@ )
+
 

--- a/test/CMake/TestApp/CMakeLists.txt
+++ b/test/CMake/TestApp/CMakeLists.txt
@@ -23,7 +23,19 @@ set( SRC_FILES
 	${SRC_DIR}/BasicApp.cpp
 )
 
-add_executable( "${EXE_NAME}" ${SRC_FILES} )
+
+if( CINDER_TARGET )
+	string( TOLOWER "${CINDER_TARGET}" CINDER_TARGET_LOWER )
+    if( "macosx" STREQUAL "${CINDER_TARGET_LOWER}" )
+        add_executable( "${EXE_NAME}" MACOSX_BUNDLE ${SRC_FILES} ${CINDER_ICON_PATH} )
+        set_source_files_properties( ${CINDER_ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources" )
+        set_target_properties( "${EXE_NAME}" PROPERTIES MACOSX_BUNDLE_NAME "${EXE_NAME}" MACOSX_BUNDLE_ICON_FILE "${CINDER_ICON_NAME}" )
+    else()
+        add_executable( "${EXE_NAME}" ${SRC_FILES} )
+    endif()
+endif()
+
+
 
 target_include_directories(
 	"${EXE_NAME}"


### PR DESCRIPTION
A first pass that illustrates how we can pass custom variables to applications linking with Cinder through `cinderConfig.cmake`. In this case we pass Cinder's icon name and path so that we can create a bundle on OS X .
